### PR TITLE
Add latest and earliest tags to History

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -9,26 +9,80 @@
 
 # Usage
 
-When any Global, Entry or Page is saved, the details are recorded.
+When any Global, Entry, or Page is saved, the details are recorded.
 
-## Tag
+## Tags
+
+By default, the {{ history }} tag will output all events that have been recorded for the Global, Entry, or Page. This can be really useful for when you need to output a log of changes made to a particular piece of content.
 
 You can display the last modified date for all content, regardless of content order (i.e. non-date collections)
 
 ```
-{{ history :id="content_id" }}
-    <p>Last modified by {{ user :id="user_id" }}{{ first_name }}{{ /user }} on {{ last_modified }}</p>
-{{ /history }}
+<ul>
+    {{ history id="content_id" }}
+        <li>Modified by {{ user :id="user_id" }}{{ first_name }}{{ /user }} on {{ last_modified }}</li>
+    {{ /history }}
+</ul>
+```
+
+But what happens if you just want to output the latest, or earliest change made to a piece of content? We'll, we've got you covered there too!
+
+### Latest
+
+Let's say you want to output the last time a particular page was updated. It's as easy as typing (or copy and pasting):
+
+```
+{{ history:latest id="content_id" }}
+    <li>Last modified by {{ user :id="user_id" }}{{ first_name }}{{ /user }} on {{ last_modified }}</li>
+{{ /history:latest }}
+```
+
+### Earliest
+
+We're sure why this would be useful, but hey, whatever. We've given you the ability to use it anyway.
+
+```
+{{ history:earliest id="content_id" }}
+    <li>First modified by {{ user :id="user_id" }}{{ first_name }}{{ /user }} on {{ last_modified }}</li>
+{{ /history:earliest }}
 ```
 
 ### Parameters
 
 * `id` - id of the content
 
+It's worth noting that you can set this up in two different ways.
+
+#### For the current page
+
+If you want to show when the latest edit to the page you're editing was, you can 'bind' the id to the context. All this means is that instead of needing to manually edit the id, or set up a custom field, you can write `:id="id"` and it'll read the id of the current page. It'll look like this:
+
+```
+{{ history:latest :id="id" }}
+    <li>Last updated by {{ user :id="user_id" }}{{ first_name }}{{ /user }} on {{ last_modified }}</li>
+{{ /history:latest }}
+```
+
+_If you look carefully, you'll notice we're using the same trick for grabbing the user that edited the content._
+
+#### For another piece of content
+
+Let's say you have a global that has a list of shareholders. When that's updated, you have to legally note when it was last updated. This is a manual job, and let's face it, people are lazy, so they'll probably forget one time. And let's face it, that one time is going to be when the regulator looks. Sods law, eh?
+
+Anyway, luckily you can automate that using this swanky addon. To do so, on the page where you output the list of shareholders, simply reference the id of the global in the history tag. It'll look something like this:
+
+```
+{{ history:latest id="id_of_global" }}
+    <li>Last modified on {{ last_modified }}</li>
+{{ /history:latest }}
+```
+
 ### Variables
 
 * `user_id` - id of the user that last updated the content
 * `last_modified` - timestamp of the last modification
+
+If you want to get fancy, you can also edit the `last_modified` variable with other modifiers like [Format](https://docs.statamic.com/modifiers/format), and [Days Ago](https://docs.statamic.com/modifiers/days_ago). Cool, right!?
 
 ## Widgets
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -13,9 +13,9 @@ When any Global, Entry, or Page is saved, the details are recorded.
 
 ## Tags
 
-By default, the {{ history }} tag will output all events that have been recorded for the Global, Entry, or Page. This can be really useful for when you need to output a log of changes made to a particular piece of content.
+By default, the {{ history }} tag will output all events that have been recorded for a Global, Entry, or Page. This can be really useful for when you need to output a log of changes made to a particular piece of content.
 
-You can display the last modified date for all content, regardless of content order (i.e. non-date collections)
+You can display the last modified date for all content, regardless of content order (i.e. non-date collections).
 
 ```
 <ul>
@@ -39,7 +39,7 @@ Let's say you want to output the last time a particular page was updated. It's a
 
 ### Earliest
 
-We're sure why this would be useful, but hey, whatever. We've given you the ability to use it anyway.
+We're not sure why this would be useful, but hey, whatever. We've given you the ability to use it anyway. As you might have guessed, it lets you output the first time a piece of content was edited after being saved.
 
 ```
 {{ history:earliest id="content_id" }}
@@ -55,7 +55,7 @@ It's worth noting that you can set this up in two different ways.
 
 #### For the current page
 
-If you want to show when the latest edit to the page you're editing was, you can 'bind' the id to the context. All this means is that instead of needing to manually edit the id, or set up a custom field, you can write `:id="id"` and it'll read the id of the current page. It'll look like this:
+If you want to show when the last edit to the page you're editing was, you can 'bind' the id to the context. All this means is that instead of needing to manually edit the id, or set up a custom field, you can write `:id="id"` and it'll read the id of the current page. It'll look like this:
 
 ```
 {{ history:latest :id="id" }}

--- a/History/HistoryTags.php
+++ b/History/HistoryTags.php
@@ -22,4 +22,38 @@ class HistoryTags extends Tags
 
         return $this->parseLoop($events);
     }
+
+    /**
+     * The {{ history:latest }} tag
+     * Returns the latest record.
+     *
+     * @return string
+     */
+    public function latest()
+    {
+        $events = Event::findbyContentId($this->get('id'));
+
+        $event = $events->map(function ($event, $key) {
+            return $event->toArray();
+        })->values()->last();
+
+        return $this->parse($event);
+    }
+
+    /**
+     * The {{ history:earliest }} tag
+     * Returns the earliest record.
+     *
+     * @return string
+     */
+    public function earliest()
+    {
+        $events = Event::findbyContentId($this->get('id'));
+
+        $event = $events->map(function ($event, $key) {
+            return $event->toArray();
+        })->values()->first();
+
+        return $this->parse($event);
+    }
 }

--- a/History/meta.yaml
+++ b/History/meta.yaml
@@ -1,5 +1,5 @@
 name: History
-version: "1.1.1"
+version: "1.2"
 description: History of user activities
 developer: Erin Dalzell
 commercial: true


### PR DESCRIPTION
Related to https://github.com/edalzell/statamic-history/issues/4.

Allows users to output just the latest record, the first entry or a list of updates.

Also expands the docs with some examples.